### PR TITLE
fix(pre-commit): correct INFRA/ path references after monorepo extraction

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,7 @@ repos:
       - id: cargo-deny
         name: cargo deny
         language: system
-        entry: cargo deny --manifest-path INFRA/kaya/Cargo.toml check advisories bans licenses sources
+        entry: cargo deny --manifest-path kaya/Cargo.toml check advisories bans licenses sources
         types: [rust]
         pass_filenames: false
         stages: [pre-push]
@@ -82,7 +82,7 @@ repos:
       - id: spdx-check
         name: SPDX license header check
         language: script
-        entry: INFRA/scripts/spdx-check.sh
+        entry: scripts/spdx-check.sh
         pass_filenames: true
         types_or: [rust, java, typescript, javascript]
 


### PR DESCRIPTION
## Contexte

Deux hooks pre-commit référencent toujours des chemins qui vivaient
sous `INFRA/` dans le mono-repo parent mais qui n'existent pas dans ce
repo :

- `cargo-deny` : `--manifest-path INFRA/kaya/Cargo.toml`
- `spdx-check` : `INFRA/scripts/spdx-check.sh`

Conséquence : `pre-commit run --all-files` échoue pour tout contributeur
qui clone le repo, et `pre-commit-ci.yml` (server-side) échoue sur
chaque PR. Ce qui forcerait à utiliser `--no-verify`, **explicitement
interdit par CLAUDE.md §4**.

## Changements

`.pre-commit-config.yaml` :
- `INFRA/kaya/Cargo.toml` → `kaya/Cargo.toml`
- `INFRA/scripts/spdx-check.sh` → `scripts/spdx-check.sh`

## Test plan

- [ ] `pre-commit run --all-files` passe localement après checkout de cette branche
- [ ] `pre-commit-ci.yml` (job CI) passe sur cette PR

## Risque & rollback

Faible. Rollback : `git revert`.

## Suite

PR liée : `fix/ci-workflows-paths-after-monorepo-extraction` (même bug,
17 workflows GitHub Actions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)